### PR TITLE
Add simple version spec to Git synth files

### DIFF
--- a/Synthesis.Bethesda.Execution/FileAssociations/AddGitPatcherInstruction.cs
+++ b/Synthesis.Bethesda.Execution/FileAssociations/AddGitPatcherInstruction.cs
@@ -1,7 +1,10 @@
-﻿namespace Synthesis.Bethesda.Execution.FileAssociations;
+﻿using Synthesis.Bethesda.Execution.Settings;
+
+namespace Synthesis.Bethesda.Execution.FileAssociations;
 
 public record AddGitPatcherInstruction
 {
     public string Url { get; init; } = string.Empty;
     public string SelectedProject { get; init; } = string.Empty;
+    public PatcherVersioningEnum Versioning { get; init; } = PatcherVersioningEnum.Branch;
 } 

--- a/Synthesis.Bethesda.Execution/FileAssociations/ExportGitAddFile.cs
+++ b/Synthesis.Bethesda.Execution/FileAssociations/ExportGitAddFile.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Abstractions;
 using Newtonsoft.Json;
 using Noggog;
+using Synthesis.Bethesda.Execution.Settings;
 
 namespace Synthesis.Bethesda.Execution.FileAssociations;
 
@@ -30,14 +31,16 @@ public class ExportGitAddFile
     public void ExportAsFile(
         FilePath path,
         string url, 
-        string selectedSubPath)
+        string selectedSubPath,
+        PatcherVersioningEnum versioning)
     {
         var dto = new MetaFileDto()
         {
             AddGitPatcher = new AddGitPatcherInstruction()
             {
                 Url = url,
-                SelectedProject = selectedSubPath
+                SelectedProject = selectedSubPath,
+                Versioning = versioning
             }
         };
         _fileSystem.File.WriteAllText(

--- a/Synthesis.Bethesda.GUI/Services/Profile/TopLevel/AddGitPatcherResponder.cs
+++ b/Synthesis.Bethesda.GUI/Services/Profile/TopLevel/AddGitPatcherResponder.cs
@@ -38,7 +38,8 @@ public class AddGitPatcherResponder
                 var gitPatcher = _patcherFactory.GetGitPatcher(new GithubPatcherSettings()
                 {
                     RemoteRepoPath = x.Url,
-                    SelectedProjectSubpath = x.SelectedProject
+                    SelectedProjectSubpath = x.SelectedProject,
+                    PatcherVersioning = x.Versioning
                 });
                 if (!await _renamer.ConfirmNameUnique(gitPatcher)) return;
                 _addPatchersToSelectedGroupVm.AddNewPatchers(gitPatcher);

--- a/Synthesis.Bethesda.GUI/ViewModels/Patchers/Git/GitPatcherVm.cs
+++ b/Synthesis.Bethesda.GUI/ViewModels/Patchers/Git/GitPatcherVm.cs
@@ -243,7 +243,8 @@ public class GitPatcherVm : PatcherVm, IPathToSolutionFileProvider
             exportGitAddFile.ExportAsFile(
                 dialog.FileName,
                 remoteRepoPathInputVm.RemoteRepoPath,
-                selectedProjectInput.ProjectSubpath);
+                selectedProjectInput.ProjectSubpath,
+                patcherTargeting.PatcherVersioning);
         });
     }
 

--- a/Synthesis.Bethesda.UnitTests/Execution/FileAssociations/AddGitPatcherPassthrough.cs
+++ b/Synthesis.Bethesda.UnitTests/Execution/FileAssociations/AddGitPatcherPassthrough.cs
@@ -14,7 +14,7 @@ public class AddGitPatcherPassthrough
         ExportGitAddFile exportGitAddFile,
         ImportMetaDto importMetaDto)
     {
-        exportGitAddFile.ExportAsFile(missingPath, add.Url, add.SelectedProject);
+        exportGitAddFile.ExportAsFile(missingPath, add.Url, add.SelectedProject, add.Versioning);
         var dto = importMetaDto.Import(missingPath);
         dto.ShouldBe(new MetaFileDto()
         {


### PR DESCRIPTION
Adds support for specifying the versioning type for the "AddGitPatcher" in .synth files.

- Manually tested **import** and **export** for all 3 modes - "Branch", "Tag" and "Commit".
- Tested that defaults for each of these modes work properly i.e. "default branch", "latest tag" and "latest commit".
- Tested that older synth files without the new parameter use the previous default "Branch".
- All existing unit tests pass.

Before:
```json
{
    "AddGitPatcher":
    {
        "Url": "https://github.com/Org/Repo",
        "SelectedProject": "Project\\Project.csproj"
    }
}
```
After:
```json
{
    "AddGitPatcher":
    {
        "Url": "https://github.com/Org/Repo",
        "SelectedProject": "Project\\Project.csproj",
        "Versioning": "Tag"
    }
}
```